### PR TITLE
０件の持っていくもの登録をできないように修正

### DIFF
--- a/app/javascript/event-new.vue
+++ b/app/javascript/event-new.vue
@@ -53,7 +53,7 @@
                 :key="n"
                 :value="n"
               >
-                {{ n-1 }}
+                {{ n }}
               </option>
             </select>
           </li>
@@ -162,6 +162,7 @@ export default {
         return false
       }
     }
+
   }
 }
 </script>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50447071/127959390-d1a3c45e-9beb-4bb7-a2c3-e62e4db76b47.png)

「0件もっていく」というシチュエーションは存在しないため